### PR TITLE
Historical Graph of Cases and Deaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ COVID-19 Tracker CLI is licensed under MIT - <https://opensource.org/licenses/MI
 
 ## Author
 
-COVID-19 Tracker CLI is Developed and Maintained by **Waren Gonzaga**
+COVID-19 Tracker CLI is Developed and Maintained by **Waren Gonzaga** and **Ian Vizarra**
 
 * **Facebook:** <https://facebook.com/warengonzagaofficial>
 * **Twitter:** <https://twitter.com/warengonzaga>

--- a/app.js
+++ b/app.js
@@ -95,6 +95,33 @@ app.get(['/plain/:country','/cmd/:country','/basic/:country'], async (req, res, 
   return next();
 });
 
+// by historical chart by country
+app.get('/history/:country/:chartType(cases|deaths)?', async (req, res, next) => {
+  const userAgent = req.headers['user-agent'],
+        countryData = req.params.country,
+        chartType = req.params.chartType || 'cases',
+        
+        summary = await axios.get(`${apiBaseURL}/countries/${countryData}`),
+        history = await axios.get(`${apiBaseURL}/v2/historical/${summary.data.country}`),
+        all = await axios.get(`${apiBaseURL}/all`),
+        s = summary.data,
+        h = history.data;
+        u = all.data;
+
+  if (util.isCommandline(userAgent)) {
+    await res.send(
+      covid19.historyCountryTracker(
+        s.country, s.cases, s.todayCases, 
+        s.deaths, s.todayDeaths, s.recovered, 
+        s.active, s.critical, s.casesPerOneMillion,
+        u.updated, h, chartType
+      )
+    );
+    return null;
+  }
+  return next();
+});
+
 app.get('*', (req, res) => res.send(`
 Welcome to COVID-19 Tracker CLI by Waren Gonzaga
 Please visit: https://warengonza.ga/covid19-tracker-cli

--- a/lib/cli/chart.js
+++ b/lib/cli/chart.js
@@ -1,0 +1,11 @@
+const chart  = require('asciichart');
+
+// generate chart for caes or deaths
+exports.generate = (data, type = 'cases') => {
+    const config = {
+        height:  12,
+        format: (x, i) => ('    ' + x.toFixed(0)).slice(-'    '.length)
+    };
+    chartData = Object.values(data.timeline[type]).flat();
+    return chart.plot(chartData, config);
+}

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2,7 +2,8 @@
 
 const color     = require('ansi-styles'),
       fs        = require('fs'),
-      table3    = require('cli-table3');
+      table3    = require('cli-table3'),
+      chart     = require('./chart');
 
 // ansi colors
 const 
@@ -250,5 +251,41 @@ exports.plaincountrytracker = (n, c, tC, d, tD, r, a, cl, cPOM, u) => {
     return n=='Philippines' ? visual+specialfooter : visual+defaultfooter;
 };
 
+exports.historyCountryTracker = (n, c, tC, d, tD, r, a, cl, cPOM, u, h, chartType) => {
+    const   name = n, cases = c, todayCases = tC,
+            deaths = d, todayDeaths = tD, recovered = r,
+            active = a, critical = cl, casesPerOneMillion = cPOM,
+            mortalityPercentage = (d/c)*100, recoveryPercentage = (r/c)*100,
+            asof = new Date(u),
+            dates = Object.keys(h.timeline[chartType]),
+            from = dates[0],
+            to = dates[dates.length - 1],
+            table = new table3({
+                head: [{colSpan: 5, content: white(`COVID-19 Tracker CLI v ${pkg.version} - ${name} Historical Chart`)}],
+                chars: borders,
+            }),
+            chartData = chart.generate(h, chartType);
+
+    table.push(
+        [{colSpan: 5, content: yellow(`As of ${asof.toLocaleString()} Date: [${currentdate}]`)}],
+        [magenta('Cases'), red('Deaths'), green('Recovered'), cyan('Active'), cyanBright('Cases/Million')],
+        [formatNumber(cases), formatNumber(deaths), formatNumber(recovered), formatNumber(active), formatNumber(casesPerOneMillion)],
+        [magentaBright('Today Cases'), redBright('Today Deaths'), redBright('Critical'), red('Mortality %'), greenBright('Recovery %')],
+        [formatNumber(todayCases), formatNumber(todayDeaths), formatNumber(critical), mortalityPercentage.toFixed(2), recoveryPercentage.toFixed(2)],
+        [{colSpan: 5, content: magenta(`${ucfirst(chartType)} from ${from} to ${to}`)}],
+        [{colSpan: 5, content: chartData}],
+        [sourceInfo],[repoInfo]
+    );
+
+    const   tableFooter = table.toString()+br+br+space+'"'+green(randomSay())+'"',
+            defaultfooter = footerOne+ansiBMC+footerTwo+ansiTwitter+br+br,
+            specialfooter = footerOne+ansiGCash+br+' '+ansiBMC+footerTwo+ansiTwitter+br+br;
+    
+    return n == 'Philippines' ? tableFooter+specialfooter : tableFooter+defaultfooter;
+}
+
 const   footerOne   = br+br+' '+line+br+' '+bmcline+br+' ',
         footerTwo   = br+' '+line+br+' '+twitterline+br+' ';
+
+// capitalize first letter
+const ucfirst = (string) => string.charAt(0).toUpperCase() + string.slice(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "covid19-tracker-cli",
-  "version": "2.1.0",
+  "version": "2.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -61,6 +61,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asciichart": {
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/asciichart/-/asciichart-1.5.15.tgz",
+      "integrity": "sha512-0XHe9H/NB1A717Ji8IhNK7NIvdqxQfEVfTVqFqkQAK06N3qqnIldsU1o4O8KuYhHoCADOiC/Xeg6ZmbJyFtrTA=="
     },
     "axios": {
       "version": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "ansi-styles": "^4.2.1",
+    "asciichart": "^1.5.15",
     "axios": "^0.19.2",
     "cli-table3": "^0.5.1",
     "express": "^4.17.1"


### PR DESCRIPTION
- Endpoint for historical graph `/history/:country/(cases|deaths)` #1 
 eg. `curl https://covid19tracker.xyz/history/ph/cases`
- Added Collaborator

Screenshot
<img width="632" alt="Screen Shot 2020-03-29 at 7 23 46 PM" src="https://user-images.githubusercontent.com/2890710/77848635-b7574780-71f8-11ea-86a3-5d129e54db5e.png">
