### PR TITLE
Use `updated` attribute from country api instead of `all`

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,15 +53,13 @@ app.get('/:country', async (req, res, next) => {
   const userAgent = req.headers['user-agent'],
         countryData = req.params.country,
         api = await axios.get(`${apiBaseURL}/countries/${countryData}`),
-        all = await axios.get(`${apiBaseURL}/all`),
-        u = all.data,
         d = api.data;
   if (util.isCommandline(userAgent)) {
     await res.send(covid19.covid19countrytracker(
       d.country, d.cases, d.todayCases, 
       d.deaths, d.todayDeaths, d.recovered, 
       d.active, d.critical, d.casesPerOneMillion,
-      u.updated
+      d.updated
     ));
     return null;
   }
@@ -73,15 +71,13 @@ app.get(['/plain/:country','/cmd/:country','/basic/:country'], async (req, res, 
   const userAgent = req.headers['user-agent'],
         countryData = req.params.country,
         api = await axios.get(`${apiBaseURL}/countries/${countryData}`),
-        all = await axios.get(`${apiBaseURL}/all`),
-        u = all.data,
         d = api.data;
   if (util.isCommandline(userAgent)) {
     await res.send(covid19.plaincountrytracker(
       d.country, d.cases, d.todayCases, 
       d.deaths, d.todayDeaths, d.recovered, 
       d.active, d.critical, d.casesPerOneMillion,
-      u.updated
+      d.updated
     ));
     return null;
   }
@@ -93,13 +89,10 @@ app.get('/history/:country/:chartType(cases|deaths)?', async (req, res, next) =>
   const userAgent = req.headers['user-agent'],
         countryData = req.params.country,
         chartType = req.params.chartType || 'cases',
-        
         summary = await axios.get(`${apiBaseURL}/countries/${countryData}`),
         history = await axios.get(`${apiBaseURL}/v2/historical/${summary.data.country}`),
-        all = await axios.get(`${apiBaseURL}/all`),
         s = summary.data,
         h = history.data;
-        u = all.data;
 
   if (util.isCommandline(userAgent)) {
     await res.send(
@@ -107,7 +100,7 @@ app.get('/history/:country/:chartType(cases|deaths)?', async (req, res, next) =>
         s.country, s.cases, s.todayCases, 
         s.deaths, s.todayDeaths, s.recovered, 
         s.active, s.critical, s.casesPerOneMillion,
-        u.updated, h, chartType
+        s.updated, h, chartType
       )
     );
     return null;


### PR DESCRIPTION
Since the API for the `country` is now returning the `updated` attribute there's no need to call the `all` API to get the `updated` value. Reducing API call = speed performance increase